### PR TITLE
fix _navigation null error on exit app

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,9 @@ export default class Navigation {
   @observable.ref navigation: NavigationScreenProp<NavigationState> | undefined;
 
   @action.bound createRef(ref: NavigationContainerComponent & { _navigation: NavigationScreenProp<NavigationState> }) {
-    this.navigation = ref._navigation;
+    if(ref){
+      this.navigation = ref._navigation;
+    }
   }
 
   @action.bound dispatch(action: NavigationAction) {


### PR DESCRIPTION
I added a value check before assign it to the variable. This will check if it has a value or none, if none it will only pass through and will not find _navigation field.